### PR TITLE
Support closures in `floating()` and `colored()` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+Both the `floating()` and `colored()` methods can receive closure that will be evaluated to determine if the theme should be applied. This allows you to apply the theme conditionally, for instance, based off of user preferences.
+
+```php
+use Awcodes\FilamentStickyHeader\StickyHeaderPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            StickyHeaderPlugin::make()
+                ->floating(fn():bool => auth()->user()->use_floating_header)
+                ->colored(fn():bool => auth()->user()->use_floating_header)
+        ])
+    ]);
+}
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/src/StickyHeaderPlugin.php
+++ b/src/StickyHeaderPlugin.php
@@ -2,29 +2,35 @@
 
 namespace Awcodes\FilamentStickyHeader;
 
+use Closure;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
+use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\Support\Facades\FilamentAsset;
 
 class StickyHeaderPlugin implements Plugin
 {
-    protected ?bool $isColored = null;
+    use EvaluatesClosures;
 
-    protected ?bool $isFloating = null;
+    protected bool | Closure | null $isColored = null;
+
+    protected bool | Closure | null $isFloating = null;
 
     public function boot(Panel $panel): void
     {
-        //
+        FilamentAsset::registerScriptData([
+            'stickyHeaderTheme' => $this->getTheme(),
+        ], 'awcodes-sticky-header');
     }
 
-    public function colored(bool $condition = true): static
+    public function colored(bool | Closure $condition = true): static
     {
         $this->isColored = $condition;
 
         return $this;
     }
 
-    public function floating(bool $condition = true): static
+    public function floating(bool | Closure $condition = true): static
     {
         $this->isFloating = $condition;
 
@@ -43,12 +49,12 @@ class StickyHeaderPlugin implements Plugin
 
     public function isColored(): bool
     {
-        return $this->isColored ?? false;
+        return $this->evaluate($this->isColored) ?? false;
     }
 
     public function isFloating(): bool
     {
-        return $this->isFloating ?? false;
+        return $this->evaluate($this->isFloating) ?? false;
     }
 
     public function getTheme(): string
@@ -72,8 +78,6 @@ class StickyHeaderPlugin implements Plugin
 
     public function register(Panel $panel): void
     {
-        FilamentAsset::registerScriptData([
-            'stickyHeaderTheme' => $this->getTheme(),
-        ], 'awcodes-sticky-header');
+        //
     }
 }


### PR DESCRIPTION
This pull request adds support for passing a closure to the `floating()` and `colored()` methods.

I think all of the changes are pretty straightforward, but I did have to move the `FilamentAsset::registerScriptData()` call into the `boot()` method instead of the `register()` method because certain things, like accessing `auth()->user()`, don't work if the closures are evaluated when the plugin is registered.