### PR TITLE
Fix: scope JS asset registration to panel context only

### DIFF
--- a/src/StickyHeaderPlugin.php
+++ b/src/StickyHeaderPlugin.php
@@ -7,6 +7,7 @@ namespace Awcodes\StickyHeader;
 use Closure;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
+use Filament\Support\Assets\Js;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\Support\Facades\FilamentAsset;
 
@@ -32,6 +33,10 @@ class StickyHeaderPlugin implements Plugin
 
     public function boot(Panel $panel): void
     {
+        FilamentAsset::register([
+            Js::make('awcodes-sticky-header', __DIR__.'/../resources/dist/sticky-header.js'),
+        ], 'awcodes-sticky-header');
+
         FilamentAsset::registerScriptData([
             'stickyHeaderTheme' => $this->getTheme(),
             'stickyHeaderActive' => $this->shouldStick(),

--- a/src/StickyHeaderServiceProvider.php
+++ b/src/StickyHeaderServiceProvider.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Awcodes\StickyHeader;
 
-use Filament\Support\Assets\Js;
-use Filament\Support\Facades\FilamentAsset;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -19,9 +17,5 @@ class StickyHeaderServiceProvider extends PackageServiceProvider
     public function packageRegistered(): void
     {
         parent::packageRegistered();
-
-        FilamentAsset::register([
-            Js::make('awcodes-sticky-header', __DIR__.'/../resources/dist/sticky-header.js'),
-        ], 'awcodes-sticky-header');
     }
 }


### PR DESCRIPTION
## Summary

- Moves `FilamentAsset::register()` from `StickyHeaderServiceProvider::packageRegistered()` into `StickyHeaderPlugin::boot()`
- The asset is now only registered when Filament boots the plugin within a panel, so it won't appear on non-panel pages that use `@filamentScripts`
- Cleans up the now-unused `Js` and `FilamentAsset` imports from the service provider

## Test plan

- [ ] Confirm the sticky header JS loads correctly on panel pages
- [ ] Confirm the sticky header JS does **not** load on non-panel pages that use `@filamentScripts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)