### PR TITLE
docs: add docs/ for the documentation hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 build
 composer.lock
 coverage
-docs
 node_modules
 phpunit.xml
 phpstan.neon

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,113 @@
+---
+title: Configuration
+description: Choose a theme and control which pages get a sticky header.
+---
+
+# Configuration
+
+Everything is set with chained methods on `StickyHeaderPlugin` in your panel provider.
+
+## Floating theme
+
+`floating()` swaps the default full-width bar for a rounded, translucent card inset from the page edges:
+
+```php
+use Awcodes\StickyHeader\StickyHeaderPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            StickyHeaderPlugin::make()
+                ->floating(),
+        ]);
+}
+```
+
+## Coloured theme
+
+`colored()` fills the floating card with the panel's primary colour and lightens the heading and breadcrumb text to match:
+
+```php
+StickyHeaderPlugin::make()
+    ->floating()
+    ->colored()
+```
+
+> [!IMPORTANT]
+> `colored()` only takes effect alongside `floating()`. On its own it does nothing — the theme resolves to the default bar — so the two are always used together.
+
+## Conditional themes
+
+Both methods accept a closure, evaluated when the page renders. This is what makes the theme a user preference rather than a panel-wide decision:
+
+```php
+use Awcodes\StickyHeader\StickyHeaderPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            StickyHeaderPlugin::make()
+                ->floating(fn (): bool => auth()->user()->use_floating_header)
+                ->colored(fn (): bool => auth()->user()->use_floating_header),
+        ]);
+}
+```
+
+Because `colored()` depends on `floating()`, a condition applied to one usually belongs on the other too.
+
+## Disabling on list pages
+
+List pages are sticky like everything else. Pass `false` to leave them alone:
+
+```php
+StickyHeaderPlugin::make()
+    ->stickOnListPages(false)
+```
+
+This is worth considering when your tables have their own sticky header row, which would otherwise sit under the page header.
+
+The check matches on the page's route name containing `index`, which is how Filament names resource list routes. A closure works here too, if the decision depends on the user or the request.
+
+## Disabling on specific pages
+
+`disabledOn()` takes an array of page classes that should keep a normal header:
+
+```php
+use Awcodes\StickyHeader\StickyHeaderPlugin;
+use App\Filament\Pages\AnotherPage;
+use App\Filament\Pages\MyCustomPage;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            StickyHeaderPlugin::make()
+                ->disabledOn([
+                    MyCustomPage::class,
+                    AnotherPage::class,
+                ]),
+        ]);
+}
+```
+
+A closure returning the array lets the list be built at runtime:
+
+```php
+StickyHeaderPlugin::make()
+    ->disabledOn(fn () => [MyCustomPage::class])
+```
+
+Any class exposing a static `getRouteName()` can be named here, which covers resource pages as well as custom ones — so a single edit page can be excluded without affecting the rest of its resource:
+
+```php
+use App\Filament\Resources\Orders\Pages\EditOrder;
+
+StickyHeaderPlugin::make()
+    ->disabledOn([
+        EditOrder::class,
+    ])
+```
+
+Classes without that method are ignored rather than raising an error, so a typo here fails quietly — check the page still scrolls as you expect after adding one.

--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -1,0 +1,8 @@
+version: 1
+
+title: Sticky Header
+
+navigation:
+  - index
+  - installation
+  - configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+---
+title: Sticky Header
+description: Keep a Filament panel's page header visible while scrolling.
+---
+
+# Sticky Header
+
+Sticky Header pins a Filament page's header to the top of the viewport once you scroll past it, so the page title, breadcrumbs, and header actions stay reachable on long pages.
+
+It applies to every page in the panel — resource pages, custom pages, dashboards — with no per-page setup.
+
+## How it behaves
+
+The header starts in its normal position. Once the page is scrolled far enough that the header would leave the viewport, it sticks, positioned just below the panel's topbar so the two never overlap.
+
+Scrolling back to the top returns it to normal. Nothing is duplicated or re-rendered — it is the same header element, restyled.
+
+## Themes
+
+Three looks are available, chosen with the [`floating()` and `colored()`](configuration.md) methods:
+
+| Theme | Appearance |
+| --- | --- |
+| Default | A full-width bar with a solid background and a bottom border |
+| Floating | A rounded, translucent card inset from the page edges |
+| Floating coloured | The floating card, filled with the panel's primary colour |
+
+The default is used when neither method is called.
+
+## Where it applies
+
+Every page by default. Two methods narrow that:
+
+- `stickOnListPages(false)` leaves list pages alone.
+- `disabledOn([...])` switches it off for named pages.
+
+Both are covered in [Configuration](configuration.md), along with the closures that let either decision be made at runtime.
+
+## Next steps
+
+Start with [Installation](installation.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,72 @@
+---
+title: Installation
+description: Install Sticky Header, register the plugin with a panel, and import its stylesheet.
+---
+
+# Installation
+
+## Requirements
+
+- PHP 8.2 or higher
+- Filament 4.x or 5.x
+
+Earlier releases of this package support earlier versions of Filament:
+
+| Package Version | Filament Version |
+| --- | --- |
+| 1.x | 2.x |
+| 2.x | 3.x |
+| 3.x | 4.x |
+| 4.x | 4.x & 5.x |
+
+## Install the package
+
+Install with Composer:
+
+```bash
+composer require awcodes/filament-sticky-header
+```
+
+The service provider is registered automatically, and there is no configuration file to publish.
+
+## Register the plugin
+
+Add the plugin to the panel:
+
+```php
+use Awcodes\StickyHeader\StickyHeaderPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            StickyHeaderPlugin::make(),
+        ]);
+}
+```
+
+That is everything. With no further configuration, every page in the panel gets a sticky header in the default theme.
+
+## Import the stylesheet
+
+Add the package's stylesheet to your theme's CSS file:
+
+```css
+@import '../../../../vendor/awcodes/filament-sticky-header/resources/css/plugin.css';
+```
+
+If you are using the standalone Filament packages rather than Panels, add the same line to your application's CSS file.
+
+> [!IMPORTANT]
+> Panel users need a custom theme before this line has anywhere to live. If you have not created one yet, follow [Creating a custom theme](https://filamentphp.com/docs/4.x/styling/overview#creating-a-custom-theme) in the Filament documentation first.
+
+The relative path above assumes the conventional theme location, `resources/css/filament/<panel>/theme.css`. Adjust the number of `../` segments if your theme lives elsewhere — the path has to resolve to `vendor/awcodes/filament-sticky-header/resources/css/plugin.css` from the file it is written in.
+
+> [!NOTE]
+> This is an `@import` of a stylesheet, not the `@source` directive other Filament plugins use. Sticky Header ships real CSS rather than classes to be scanned out of Blade views, so `@source` would find nothing.
+
+Without this import the JavaScript still runs and the header still becomes sticky, but with no styling to distinguish it — no background, no border, no shadow — so it will overlap the content beneath it.
+
+## Next steps
+
+See [Configuration](configuration.md) for themes and for turning the header off on particular pages.


### PR DESCRIPTION
Adds a structured `docs/` directory so this package can be published to the documentation hub.

- Stops `.gitignore` from ignoring `docs`.
- Adds 3 pages: index, installation, configuration.

Docs are version-scoped by branch, so these are the 4.x docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)