### PR TITLE
fix: correct the bracket mismatch in every README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ public function panel(Panel $panel): Panel
     return $panel
         ->plugins([
             StickyHeaderPlugin::make(),
-        ])
-    ])
+        ]);
 }
 ```
 
@@ -68,8 +67,7 @@ public function panel(Panel $panel): Panel
             StickyHeaderPlugin::make()
                 ->floating()
                 ->colored()
-        ])
-    ]);
+        ]);
 }
 ```
 
@@ -85,8 +83,7 @@ public function panel(Panel $panel): Panel
             StickyHeaderPlugin::make()
                 ->floating(fn():bool => auth()->user()->use_floating_header)
                 ->colored(fn():bool => auth()->user()->use_floating_header)
-        ])
-    ]);
+        ]);
 }
 ```
 
@@ -103,8 +100,7 @@ public function panel(Panel $panel): Panel
         ->plugins([
             StickyHeaderPlugin::make()
                 ->stickOnListPages(false)
-        ])
-    ]);
+        ]);
 }
 ```
 
@@ -126,8 +122,7 @@ public function panel(Panel $panel): Panel
                     MyCustomPage::class,
                     AnotherPage::class,
                 ])
-        ])
-    ]);
+        ]);
 }
 ```
 


### PR DESCRIPTION
Every panel example in the README closed the `plugins([...])` array and then closed a second array that was never opened, and dropped the statement's semicolon:

```php
        ->plugins([
            StickyHeaderPlugin::make(),
        ])
    ])
}
```

Copying any of them into a panel provider is a parse error. Corrected to `]);` in all five examples. Documentation only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)